### PR TITLE
Fix result label after each guess

### DIFF
--- a/src/main/java/com/mycompany/guessgame/Guess_Game.java
+++ b/src/main/java/com/mycompany/guessgame/Guess_Game.java
@@ -217,11 +217,15 @@ public class Guess_Game extends javax.swing.JFrame {
 
     private void jButton_Next_ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton_Next_ActionPerformed
         // check the word/ display the next word
-         checkWord();
+        checkWord();
         if(index < words.length - 1)
         {
-           index++;
-           displayWord(); 
+            index++;
+            displayWord();
+
+            // reset the result label for the next guess
+            jLabel_Result.setText("Result");
+            jLabel_Result.setBackground(new java.awt.Color(102, 102, 102));
         }
     }//GEN-LAST:event_jButton_Next_ActionPerformed
 


### PR DESCRIPTION
## Summary
- reset result label when moving to the next word

## Testing
- `javac src/main/java/com/mycompany/guessgame/Guess_Game.java`

------
https://chatgpt.com/codex/tasks/task_e_6840dd277668832c82991dc0c57f423d