### PR TITLE
Add simple AI tools website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 ![Describe_Game](https://github.com/lotfibelaid/guess_game/assets/92277243/3d9da823-88ac-4d07-b84f-718951f3aba0)
 
 ![Describe_Game2](https://github.com/lotfibelaid/guess_game/assets/92277243/9f1d467e-e2bb-47bd-91e7-629d9cb92b64)
+
+## AI Tools Website
+
+This repository also includes a simple web page listing some of the latest AI tools and short instructions on how to use them. You can open `ai-tools-site/index.html` in a browser to view it.

--- a/ai-tools-site/index.html
+++ b/ai-tools-site/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Latest AI Tools</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Latest AI Tools and How to Use Them</h1>
+        <p>A quick overview of some recent AI tools, how they can help, and the domains where they excel.</p>
+    </header>
+
+    <main>
+        <section class="tool">
+            <h2>ChatGPT (OpenAI)</h2>
+            <p class="domain"><strong>Domain:</strong> General language tasks, coding help, brainstorming.</p>
+            <p><strong>How to Use:</strong> Sign up on <a href="https://chat.openai.com" target="_blank">chat.openai.com</a>, then simply start chatting with the model. You can ask questions, request code snippets, or brainstorm ideas.</p>
+        </section>
+
+        <section class="tool">
+            <h2>DALL·E 3 (OpenAI)</h2>
+            <p class="domain"><strong>Domain:</strong> Image generation, creative design.</p>
+            <p><strong>How to Use:</strong> Access DALL·E via OpenAI's platform, type a description of the image you want, and the model will generate artwork based on your prompt.</p>
+        </section>
+
+        <section class="tool">
+            <h2>Midjourney</h2>
+            <p class="domain"><strong>Domain:</strong> Digital art, concept design.</p>
+            <p><strong>How to Use:</strong> Join the Midjourney Discord server, then use the <code>/imagine</code> command followed by your description to generate images.</p>
+        </section>
+
+        <section class="tool">
+            <h2>GitHub Copilot</h2>
+            <p class="domain"><strong>Domain:</strong> Software development.</p>
+            <p><strong>How to Use:</strong> Install the Copilot extension in VS Code, then start typing code. Copilot suggests completions and entire functions based on the context.</p>
+        </section>
+
+        <section class="tool">
+            <h2>Google Bard</h2>
+            <p class="domain"><strong>Domain:</strong> Search assistance, general Q&A.</p>
+            <p><strong>How to Use:</strong> Visit the Bard website and ask questions or request explanations. Bard generates responses that can help with research and content creation.</p>
+        </section>
+    </main>
+
+    <footer>
+        <p>Updated 2023. Content will be expanded as new tools appear.</p>
+    </footer>
+</body>
+</html>

--- a/ai-tools-site/style.css
+++ b/ai-tools-site/style.css
@@ -1,0 +1,43 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+header {
+    background-color: #222;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+
+main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+.tool {
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.tool h2 {
+    margin-top: 0;
+}
+
+.domain {
+    font-style: italic;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: #222;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- add a simple static site in `ai-tools-site` that showcases some recent AI tools and how to use them
- update README with instructions about the new site

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dd5e3278832ca2e2b41cf166c177